### PR TITLE
Add Gemini 2.5 thinking budget

### DIFF
--- a/app/client/api.ts
+++ b/app/client/api.ts
@@ -52,6 +52,8 @@ export interface LLMConfig {
   stream?: boolean;
   presence_penalty?: number;
   frequency_penalty?: number;
+  max_tokens?: number;
+  thinking_budget?: number;
   size?: DalleRequestPayload["size"];
   quality?: DalleRequestPayload["quality"];
   style?: DalleRequestPayload["style"];

--- a/app/client/platforms/google.ts
+++ b/app/client/platforms/google.ts
@@ -151,6 +151,9 @@ export class GeminiProApi implements LLMApi {
         temperature: modelConfig.temperature,
         maxOutputTokens: modelConfig.max_tokens,
         topP: modelConfig.top_p,
+        ...(modelConfig.thinking_budget > 0
+          ? { thinkingBudget: modelConfig.thinking_budget }
+          : {}),
         // "topK": modelConfig.top_k,
       },
       safetySettings: [

--- a/app/components/model-config.tsx
+++ b/app/components/model-config.tsx
@@ -110,6 +110,28 @@ export function ModelConfigList(props: {
         ></input>
       </ListItem>
 
+      <ListItem
+        title={Locale.Settings.ThinkingBudget.Title}
+        subTitle={Locale.Settings.ThinkingBudget.SubTitle}
+      >
+        <input
+          aria-label={Locale.Settings.ThinkingBudget.Title}
+          type="number"
+          min={0}
+          max={32768}
+          value={props.modelConfig.thinking_budget ?? 0}
+          onChange={(e) =>
+            props.updateConfig(
+              (config) =>
+                (config.thinking_budget =
+                  ModalConfigValidator.thinking_budget(
+                    e.currentTarget.valueAsNumber,
+                  )),
+            )
+          }
+        ></input>
+      </ListItem>
+
       {props.modelConfig?.providerName == ServiceProvider.Google ? null : (
         <>
           <ListItem

--- a/app/constant.ts
+++ b/app/constant.ts
@@ -365,6 +365,7 @@ const googleModels = [
   "gemini-exp-1206",
   "gemini-2.0-flash-exp",
   "gemini-2.0-flash-thinking-exp-1219",
+  "gemini-2.5-pro-0605",
 ];
 
 const anthropicModels = [

--- a/app/locales/cn.ts
+++ b/app/locales/cn.ts
@@ -546,6 +546,10 @@ const cn = {
       Title: "单次回复限制 (max_tokens)",
       SubTitle: "单次交互所用的最大 Token 数",
     },
+    ThinkingBudget: {
+      Title: "思考预算 (thinking_budget)",
+      SubTitle: "指导模型投入更多思考步骤",
+    },
     PresencePenalty: {
       Title: "话题新鲜度 (presence_penalty)",
       SubTitle: "值越大，越有可能扩展到新话题",

--- a/app/locales/en.ts
+++ b/app/locales/en.ts
@@ -551,6 +551,10 @@ const en: LocaleType = {
       Title: "Max Tokens",
       SubTitle: "Maximum length of input tokens and generated tokens",
     },
+    ThinkingBudget: {
+      Title: "Thinking Budget",
+      SubTitle: "Guide the model to spend more effort on reasoning",
+    },
     PresencePenalty: {
       Title: "Presence Penalty",
       SubTitle:

--- a/app/store/config.ts
+++ b/app/store/config.ts
@@ -81,6 +81,7 @@ export const DEFAULT_CONFIG = {
     size: "1024x1024" as ModelSize,
     quality: "standard" as DalleQuality,
     style: "vivid" as DalleStyle,
+    thinking_budget: 0,
   },
 
   ttsConfig: {
@@ -159,6 +160,9 @@ export const ModalConfigValidator = {
   top_p(x: number) {
     return limitNumber(x, 0, 1, 1);
   },
+  thinking_budget(x: number) {
+    return limitNumber(x, 0, 32768, 0);
+  },
 };
 
 export const useAppConfig = createPersistStore(
@@ -195,7 +199,7 @@ export const useAppConfig = createPersistStore(
   }),
   {
     name: StoreKey.Config,
-    version: 4.1,
+    version: 4.2,
 
     merge(persistedState, currentState) {
       const state = persistedState as ChatConfig | undefined;
@@ -253,6 +257,10 @@ export const useAppConfig = createPersistStore(
           DEFAULT_CONFIG.modelConfig.compressModel;
         state.modelConfig.compressProviderName =
           DEFAULT_CONFIG.modelConfig.compressProviderName;
+      }
+
+      if (version < 4.2) {
+        state.modelConfig.thinking_budget = 0;
       }
 
       return state as any;


### PR DESCRIPTION
## Summary
- add `gemini-2.5-pro-0605` model constant
- support `thinking_budget` in config and Google request
- expose Thinking Budget option in settings UI
- add English/Chinese locale for the new setting
- bump config store version to 4.2

## Testing
- `yarn install` *(fails: trouble with network connection)*
- `yarn test:ci` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684262f441088331b30215e2bb8bc763